### PR TITLE
hot fix for missing babel dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "axios-retry": "^3.0.1",
     "crypto-js": "^3.3.0",
     "url": "^0.11.0",
-    "url-template": "^2.0.8"
+    "url-template": "^2.0.8",
+    "@babel/runtime": "^7.7.7"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.7",
@@ -41,7 +42,6 @@
     "@babel/plugin-transform-runtime": "^7.7.6",
     "@babel/preset-env": "^7.7.7",
     "@babel/register": "^7.7.7",
-    "@babel/runtime": "^7.7.7",
     "ava": "^2.4.0",
     "eslint": "^6.8.0",
     "nyc": "^14.1.1"


### PR DESCRIPTION
Fixed missing `@babel/runtime` dep. In the future want to remove this and avoid having this dependency.